### PR TITLE
updated project name, fixed link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For more awesome lists, see [awesome](https://github.com/sindresorhus/awesome).
 * [Boa](http://boa.cs.iastate.edu/) - a domain-specific language and infrastructure that eases mining software repositories
 * [Code Reviews](http://kin-y.github.io/miningReviewRepo/) - Code reviews of OpenStack, LibreOffice, AOSP, Qt, Eclipse
 * [Enron Spreadsheets and Emails](https://figshare.com/articles/Enron_Spreadsheets_and_Emails/1221767) - all the spreadsheets and emails used in the paper 'Enron's Spreadsheets and Related Emails: A Dataset and Analysis'
-* [Findbugs-maven](https://github.com/bkarak/data_msr2015) - a set of FindBugs reports for the Java projects of the [Maven repository](https://maven.apache.org)
+* [The Bug Catalog of the Maven Ecosystem](https://github.com/istlab/maven_bug_catalog) - a set of FindBugs reports for the Java projects of the [Maven repository](https://maven.apache.org)
 * [GHTorrent](http://ghtorrent.org/) - an effort to create a scalable, queriable, offline mirror of data offered through the Github REST API
 * [Maven metrics](https://github.com/bkarak/data_msr2015) - a collection of software complexity & sizing metrics for the [Maven Repository](https://maven.apache.org)
 * [mzdata](https://github.com/jxshin/mzdata) -  Multi-extract and Multi-level Dataset of Mozilla Issue Tracking History

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For more awesome lists, see [awesome](https://github.com/sindresorhus/awesome).
 * [Boa](http://boa.cs.iastate.edu/) - a domain-specific language and infrastructure that eases mining software repositories
 * [Code Reviews](http://kin-y.github.io/miningReviewRepo/) - Code reviews of OpenStack, LibreOffice, AOSP, Qt, Eclipse
 * [Enron Spreadsheets and Emails](https://figshare.com/articles/Enron_Spreadsheets_and_Emails/1221767) - all the spreadsheets and emails used in the paper 'Enron's Spreadsheets and Related Emails: A Dataset and Analysis'
-* [The Bug Catalog of the Maven Ecosystem](https://github.com/istlab/maven_bug_catalog) - a set of FindBugs reports for the Java projects of the [Maven repository](https://maven.apache.org)
+* [Findbugs-maven](https://github.com/istlab/maven_bug_catalog) - a set of FindBugs reports for the Java projects of the [Maven repository](https://maven.apache.org)
 * [GHTorrent](http://ghtorrent.org/) - an effort to create a scalable, queriable, offline mirror of data offered through the Github REST API
 * [Maven metrics](https://github.com/bkarak/data_msr2015) - a collection of software complexity & sizing metrics for the [Maven Repository](https://maven.apache.org)
 * [mzdata](https://github.com/jxshin/mzdata) -  Multi-extract and Multi-level Dataset of Mozilla Issue Tracking History


### PR DESCRIPTION
the link was the same with the "Maven metrics" project.
