### PR TITLE
Add RepoReapers data set and associated tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ For more awesome lists, see [awesome](https://github.com/sindresorhus/awesome).
 * [GHTorrent](http://ghtorrent.org/) - an effort to create a scalable, queriable, offline mirror of data offered through the Github REST API
 * [Maven metrics](https://github.com/bkarak/data_msr2015) - a collection of software complexity & sizing metrics for the [Maven Repository](https://maven.apache.org)
 * [mzdata](https://github.com/jxshin/mzdata) -  Multi-extract and Multi-level Dataset of Mozilla Issue Tracking History
+* [RepoReapers Data Set](https://reporeapers.github.io) - A data set containing a collection of _engineered software projects_ from GHTorrent.
 * [Stack Exchange](https://archive.org/details/stackexchange) - an anonymized dump of all user-contributed content on the Stack Exchange network.
 * [tera-PROMISE](http://openscience.us/repo/) - a research dataset repository specializing in software engineering research datasets
 * [TravisTorrent](http://travistorrent.testroots.org) - TravisTorrent provides free and easy-to-use Traivs CI build analyses.
@@ -25,6 +26,7 @@ For more awesome lists, see [awesome](https://github.com/sindresorhus/awesome).
 * [MetricMiner](http://www.github.com/mauricioaniche/metricminer2) - a lean Java DSL to
 mine and extract data (e.g. commits, developers, modifications, diffs) from Git and SVN repositories
 * [qmcalc](https://github.com/dspinellis/cqmetrics) - calculate quality metrics from C source code
+* [`reaper`](https://github.com/RepoReapers/reaper) - A Python tool to compute a score for a repository from GHTorrent. The score quantifies the extent to which the project contained within the repository is _engineered_.
 
 ## License
 


### PR DESCRIPTION
RepoReapers is a project out of Rochester Institute of Technology in which we are attempting to separate the signal (i.e. repositories containing engineered software projects) from the noise (i.e. repositories containing class assignments, example programs, images only, text only, etc.). The data set is aimed at helping MSR researchers choose repositories that are representative of engineered software projects. The tool, `reaper`, that was used to generate the data set is also available to allow researchers to run similar analysis on repositories of their choosing.

Specifics of the tool may be found in the README.md file in the [GitHub repository](https://github.com/RepoReapers/reaper) or from the draft version of the [research paper](https://reporeapers.github.io/static/downloads/Curating%20GitHub%20for%20Engineered%20Software%20Projects.pdf).
