### PR TITLE
Changes to add SeaCraft

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For more awesome lists, see [awesome](https://github.com/sindresorhus/awesome).
 * [mzdata](https://github.com/jxshin/mzdata) -  Multi-extract and Multi-level Dataset of Mozilla Issue Tracking History
 * [RepoReapers Data Set](https://reporeapers.github.io) - A data set containing a collection of _engineered software projects_ from GHTorrent.
 * [Stack Exchange](https://archive.org/details/stackexchange) - an anonymized dump of all user-contributed content on the Stack Exchange network.
-* [tera-PROMISE](http://openscience.us/repo/) - a research dataset repository specializing in software engineering research datasets
+* [tera-PROMISE](http://openscience.us/repo/) - a research dataset repository specializing in software engineering research datasets. This has now been moved to [Zenodo](https://zenodo.org) and is called [SeaCraft](http://zenodo.org/communities/seacraft)
 * [TravisTorrent](http://travistorrent.testroots.org) - TravisTorrent provides free and easy-to-use Traivs CI build analyses.
 * [Unix history](https://github.com/dspinellis/unix-history-repo) - a Git repository with 46 years of Unix history evolution
 


### PR DESCRIPTION
Tera-promise has been moved to Zenodo and is currently called SeaCraft. This move has been mentioned along with the tera-promise entry.