### PR TITLE
Added Maven dependency graph to data sets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Many of the data set can also be useful in research using [search-based software
 * [GitHub on Google BigQuery](https://cloud.google.com/bigquery/public-data/github) - GitHub data accessible through Google's BigQuery platform
 * [KaVE](http://www.kave.cc/datasets) - Developer tool interaction data
 * [Maven metrics](https://github.com/bkarak/data_msr2015) - Collection of software complexity & sizing metrics for the [Maven Repository](https://maven.apache.org)
+* [Maven Dependency Graph](https://zenodo.org/record/1489120) - Snapshot of the whole Maven Central taken on September 6, 2018, stored in a graph database
 * [mzdata](https://github.com/jxshin/mzdata) - Multi-extract and multi-level dataset of Mozilla issue tracking history
 * [npm-miner](https://github.com/AuthEceSoftEng/msr-2018-npm-miner) - The dataset contains the analysis results of 5 open source software quality tools eslint, escomplex, nsp, jsinspect and sonarjs for 2000 popular (in terms of stars and downloads) npm packages.
 * [OCL Expressions on GitHub](https://github.com/tue-mdse/ocl-dataset) - Data set of 9188 OCL expressions originating from 504 EMF meta-models in 245 systematically selected GitHub repositories.


### PR DESCRIPTION
Dear Spinellis,

On behalf of my colleagues, I would like to contribute to this repository by adding Maven Dependency Graph, a snapshot of the whole Maven Central taken on September 6, 2018, stored in a graph database.

Please, do not hesitate to contact me if you require further information.

Kind regards,
Amine,