### PR TITLE
Addition of the GitHub Java Corpus by Allamanis et al from MSR'13

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For examples of such work see the MSR conference's [Hall of Fame](http://2016.ms
 - [Findbugs-maven](https://github.com/istlab/maven_bug_catalog) - Set of FindBugs reports for the Java projects of the [Maven repository](https://maven.apache.org).
 - [GHTorrent](http://ghtorrent.org/) - Scalable, queriable, offline mirror of data offered through the GitHub REST API.
 - [GitHub Bug Dataset](http://www.inf.u-szeged.hu/~ferenc/papers/GitHubBugDataSet/) - Bug Dataset of 15 Java open-source projects characterized by static source code metrics.
-- [GitHub Java Corpus](http://groups.inf.ed.ac.uk/cup/javaGithub/) - Corpus of 14765 Java projects filtered to have an above-average quality.
+- [GitHub Java Corpus](http://groups.inf.ed.ac.uk/cup/javaGithub/) - Large scale corpus of 14765 Java projects filtered to have an above-average quality.
 - [GitHub on Google BigQuery](https://cloud.google.com/bigquery/public-data/github) - GitHub data accessible through Google's BigQuery platform.
 - [Grammar Zoo](http://slebok.github.io/zoo/) - Collection of grammars of DSLs and GPLs, some extracted from metamodels and document schemata.
 - [KaVE](http://www.kave.cc/datasets) - Developer tool interaction data.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ For examples of such work see the MSR conference's [Hall of Fame](http://2016.ms
 - [Findbugs-maven](https://github.com/istlab/maven_bug_catalog) - Set of FindBugs reports for the Java projects of the [Maven repository](https://maven.apache.org).
 - [GHTorrent](http://ghtorrent.org/) - Scalable, queriable, offline mirror of data offered through the GitHub REST API.
 - [GitHub Bug Dataset](http://www.inf.u-szeged.hu/~ferenc/papers/GitHubBugDataSet/) - Bug Dataset of 15 Java open-source projects characterized by static source code metrics.
+- [GitHub Java Corpus](http://groups.inf.ed.ac.uk/cup/javaGithub/) - Corpus of 14765 Java projects filtered to have an above-average quality.
 - [GitHub on Google BigQuery](https://cloud.google.com/bigquery/public-data/github) - GitHub data accessible through Google's BigQuery platform.
 - [Grammar Zoo](http://slebok.github.io/zoo/) - Collection of grammars of DSLs and GPLs, some extracted from metamodels and document schemata.
 - [KaVE](http://www.kave.cc/datasets) - Developer tool interaction data.


### PR DESCRIPTION
I'm proposing to add the GitHub Java Corpus created by Miltiadis Allamanis and Charles Sutton for the article "Mining Source Code Repositories at Massive Scale using Language Modeling" published at MSR 2013.

The corpus contains a list of 14 765 java projects hosted on GitHub and the snapshot of their source code.

The primary motivation to add this dataset is because it contains a large scale collection of named java projects. The website contains the description of how the dataset has been made, clear instructions to attribute and cite the dataset, and two convenient main archives containing:
1. The list of all the projects with their URL and revision (1.4MB).
2. The source files for all the projects listed in 1. (1.8GB).

Additionally, the article has been cited 150 times (Google Scholar on 08.07.2019), showing that researchers (other than the original authors) are using the dataset actively, or at least know its existence, but that it hasn't established itself as a staple among the SE research community.

The goal is not to promote dataset unicity but rather to raise awareness on an existing work that has to been known when looking for or working with large scale Java analysis.

Concerning the stability of the URL, it is not up to the gold standard, but it should be fine. The University of Edinburgh hosts it on the CUP group's website led by Charles Sutton.